### PR TITLE
Create Service Function To Query Applications

### DIFF
--- a/src/services/applications.ts
+++ b/src/services/applications.ts
@@ -1,0 +1,31 @@
+import * as admin from "firebase-admin";
+
+const apiKey: string = import.meta.env.VITE_FIREBASE_API_KEY;
+
+admin.initializeApp({
+    credential: admin.credential.cert(JSON.parse(apiKey)),
+    databaseURL: "https://hawkhacks-dashboard.firebaseapp.com",
+});
+
+const db = admin.firestore();
+
+export const getApplications = async (
+    hackathonTerm: string
+): Promise<Record<string, unknown>[]> => {
+    try {
+        const querySnapshot = await db
+            .collection("applications")
+            .where("hackathonTerm", "==", hackathonTerm)
+            .get();
+
+        const applications: Record<string, unknown>[] = [];
+        querySnapshot.forEach((doc) => {
+            applications.push(doc.data());
+        });
+
+        return applications;
+    } catch (error) {
+        console.error("Error retrieving applications:", error);
+        throw error;
+    }
+};

--- a/src/services/applications.ts
+++ b/src/services/applications.ts
@@ -1,21 +1,35 @@
-import * as admin from "firebase-admin";
+import firebase from "firebase/compat/app";
+import "firebase/compat/firestore";
+import "firebase/compat/auth";
 
-const apiKey: string = import.meta.env.VITE_FIREBASE_API_KEY;
+const firebaseConfig = {
+    apiKey: import.meta.env.VITE_FIREBASE_API_KEY,
+    authDomain: import.meta.env.VITE_FIREBASE_AUTH_DOMAIN,
+    projectId: import.meta.env.VITE_FIREBASE_PROJECT_ID,
+    storageBucket: import.meta.env.VITE_FIREBASE_STORAGE_BUCKET,
+    messagingSenderId: import.meta.env.VITE_FIREBASE_MESSAGING_SENDER_ID,
+    appId: import.meta.env.VITE_FIREBASE_APP_ID,
+};
 
-admin.initializeApp({
-    credential: admin.credential.cert(JSON.parse(apiKey)),
-    databaseURL: "https://hawkhacks-dashboard.firebaseapp.com",
-});
+firebase.initializeApp(firebaseConfig);
 
-const db = admin.firestore();
+const db = firebase.firestore();
+const auth = firebase.auth();
 
 export const getApplications = async (
     hackathonTerm: string
 ): Promise<Record<string, unknown>[]> => {
     try {
+        const user = auth.currentUser;
+
+        if (!user) {
+            throw new Error("User not authenticated");
+        }
+
         const querySnapshot = await db
             .collection("applications")
             .where("hackathonTerm", "==", hackathonTerm)
+            .where("userId", "==", user.uid)
             .get();
 
         const applications: Record<string, unknown>[] = [];

--- a/src/services/applications.ts
+++ b/src/services/applications.ts
@@ -1,6 +1,12 @@
-import firebase from "firebase/compat/app";
-import "firebase/compat/firestore";
-import "firebase/compat/auth";
+import { initializeApp } from "firebase/app";
+import {
+    getFirestore,
+    collection,
+    query,
+    where,
+    getDocs,
+} from "firebase/firestore";
+import { getAuth, User } from "firebase/auth";
 
 const firebaseConfig = {
     apiKey: import.meta.env.VITE_FIREBASE_API_KEY,
@@ -11,26 +17,27 @@ const firebaseConfig = {
     appId: import.meta.env.VITE_FIREBASE_APP_ID,
 };
 
-firebase.initializeApp(firebaseConfig);
-
-const db = firebase.firestore();
-const auth = firebase.auth();
+const firebaseApp = initializeApp(firebaseConfig);
+const db = getFirestore(firebaseApp);
+const auth = getAuth(firebaseApp);
 
 export const getApplications = async (
     hackathonTerm: string
 ): Promise<Record<string, unknown>[]> => {
     try {
-        const user = auth.currentUser;
+        const user: User | null = auth.currentUser;
 
         if (!user) {
             throw new Error("User not authenticated");
         }
 
-        const querySnapshot = await db
-            .collection("applications")
-            .where("hackathonTerm", "==", hackathonTerm)
-            .where("userId", "==", user.uid)
-            .get();
+        const q = query(
+            collection(db, "applications"),
+            where("hackathonTerm", "==", hackathonTerm),
+            where("userId", "==", user.uid)
+        );
+
+        const querySnapshot = await getDocs(q);
 
         const applications: Record<string, unknown>[] = [];
         querySnapshot.forEach((doc) => {

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,1 +1,10 @@
 /// <reference types="vite/client" />
+interface ImportMetaEnv {
+    VITE_FIREBASE_API_KEY: string;
+    VITE_FIREBASE_AUTH_DOMAIN: string;
+    VITE_FIREBASE_PROJECT_ID: string;
+    VITE_FIREBASE_STORAGE_BUCKET: string;
+    VITE_FIREBASE_MESSAGING_SENDER_ID: string;
+    VITE_FIREBASE_APP_ID: string;
+    VITE_FIREBASE_MEASUREMENT_ID: string;
+}


### PR DESCRIPTION
Uses firebase-admin to establish a connection with firestore and uses function "getApplications" to take "hackathonTerm" in order to query hacker applications from firestore.

Not sure if I'm importing the env properly here.