### PR TITLE
Bug/96/login-enter-password-reset-issue

### DIFF
--- a/src/pages/Login/Login.page.tsx
+++ b/src/pages/Login/Login.page.tsx
@@ -198,6 +198,7 @@ export const LoginPage = () => {
                                             <div className="flex justify-end">
                                                 <button
                                                     className="text-charcoalBlack font-bold underline hover:text-tbrand-hover"
+                                                    type="button"
                                                     onClick={
                                                         toggleResetPassword
                                                     }


### PR DESCRIPTION
When a user presses Enter to submit the login form, the page redirects them to Forgot Password. 

Fixed it by explicitly making the Forgot Password button a non-submit button. 