### PR TITLE
Fix/107/make button styles match figma

### DIFF
--- a/src/components/Button/Button.styles.ts
+++ b/src/components/Button/Button.styles.ts
@@ -2,9 +2,10 @@ import { cva, type VariantProps } from "class-variance-authority";
 import type { ClassProp } from "class-variance-authority/types";
 import { twMerge } from "tailwind-merge";
 
+
 const buttonStyles = cva(
     [
-        "px-5 py-4 text-sm font-regular transition relative",
+        "px-5 py-4 text-sm font-regular transition relative rounded-sm",
         "focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-tbrand",
         "disabled:cursor-not-allowed disabled:after:hidden",
     ],
@@ -12,7 +13,7 @@ const buttonStyles = cva(
         variants: {
             intent: {
                 primary:
-                    "bg-tbrand text-white hover:bg-[#3f9098] disabled:hover:bg-tbrand active:bg-[#214b4f]",
+                    "bg-gradient-to-b from-[#256062] to-[#00959a] text-white hover:bg-[#3f9098] disabled:hover:bg-tbrand active:bg-[#214b4f] dark:bg-[#1f4245]",
                 secondary:
                     "bg-white text-tbrand border border-gray-400 hover:bg-[#ebebeb] disabled:hover:bg-white active:bg-[#d9d9d9]",
             },


### PR DESCRIPTION
Fix/107/make button styles match figma

🎨[Make Button Styles Match Figma #107](https://github.com/LaurierHawkHacks/Dashboard/issues/107)

🔍 **What's Included**
- Updated button styles in `Button.styles.ts` for alignment with Figma designs.
- Added rounded corners and gradient backgrounds for primary buttons.

📁 Files Affected:
- `src/components/Button/Button.styles.ts`