### PR TITLE
Fix/111/urgent cant go back in application if current page isnt filled

### DIFF
--- a/src/pages/Application/Application.page.tsx
+++ b/src/pages/Application/Application.page.tsx
@@ -109,7 +109,6 @@ export const ApplicationPage = () => {
 
     const prevStep = () => {
         if (activeStep > 0) {
-            if (!validate()) return;
             setActiveStep((s) => s - 1);
         }
     };


### PR DESCRIPTION
🚨[URGENT: Can't Go Back in the Application If the Current Page Isn't Filled In #111](https://github.com/LaurierHawkHacks/Dashboard/issues/111)

🔍 **What's Included**
- Removed unnecessary validation check from the back button functionality in `Application.page.tsx`.

📁 Files Affected:
- `src/pages/Application/Application.page.tsx`