### PR TITLE
Fix/109/filtered-dropdowns-on-click

### DIFF
--- a/src/components/MultiSelect/MultiSelect.tsx
+++ b/src/components/MultiSelect/MultiSelect.tsx
@@ -1,4 +1,4 @@
-import { FC, Fragment, useRef, useState } from "react";
+import { FC, Fragment, useRef, useState, useEffect } from "react";
 import { Combobox, Transition } from "@headlessui/react";
 import {
     CheckIcon,
@@ -82,11 +82,30 @@ export const MultiSelect: FC<MultiSelectProps> = ({
     const [selected, setSelected] = useState<string[]>(initialValues);
     const [query, setQuery] = useState("");
     const randomId = useRef(Math.random().toString(32));
+    const inputRef = useRef<HTMLInputElement | null>(null);
+    const comboboxButtonRef = useRef<HTMLButtonElement | null>(null); // Added ref for Combobox.Button
 
     const handleChange = (opts: string[]) => {
         setSelected(opts);
         if (onChange) onChange(opts);
     };
+
+    useEffect(() => {
+        const handleKeyDown = (event: KeyboardEvent) => {
+            if (
+                event.key === "ArrowDown" &&
+                inputRef.current === document.activeElement
+            ) {
+                setQuery("");
+            }
+        };
+
+        document.addEventListener("keydown", handleKeyDown);
+
+        return () => {
+            document.removeEventListener("keydown", handleKeyDown);
+        };
+    }, []);
 
     const filteredOptions =
         query === ""
@@ -137,8 +156,14 @@ export const MultiSelect: FC<MultiSelectProps> = ({
                         className="w-full border-none py-2 pl-3 pr-10 leading-5 text-gray-900 bg-gray-50 focus:ring-0"
                         onChange={(event) => setQuery(event.target.value)}
                         aria-describedby={describedby}
+                        onFocus={() => setQuery("")}
+                        ref={inputRef}
+                        onClick={() => comboboxButtonRef.current?.click()} // Added to handle click and focus event to open the combobox
                     />
-                    <Combobox.Button className="absolute inset-y-0 right-0 flex items-center pr-2">
+                    <Combobox.Button
+                        ref={comboboxButtonRef}
+                        className="absolute inset-y-0 right-0 flex items-center pr-2"
+                    >
                         <ChevronUpDownIcon
                             className="h-5 w-5 text-gray-400"
                             aria-hidden="true"
@@ -182,10 +207,18 @@ export const MultiSelect: FC<MultiSelectProps> = ({
                                 >
                                     {({ selected, active }) => (
                                         <>
-                                            <span>{opt}</span>
+                                            <span
+                                                className={`block truncate ${
+                                                    selected
+                                                        ? "font-medium"
+                                                        : "font-normal"
+                                                }`}
+                                            >
+                                                {opt}
+                                            </span>
                                             {selected ? (
                                                 <span
-                                                    className={`absolute inset-y-0 right-0 flex items-center pr-3 ${
+                                                    className={`absolute inset-y-0 left-0 flex items-center pl-3 ${
                                                         active
                                                             ? "text-white"
                                                             : "text-green-600"

--- a/src/components/Select/Select.tsx
+++ b/src/components/Select/Select.tsx
@@ -1,6 +1,7 @@
 import { FC, Fragment, useState, useRef, useEffect } from "react";
 import { Combobox, Transition } from "@headlessui/react";
 import { CheckIcon, ChevronUpDownIcon } from "@heroicons/react/20/solid";
+import { getOptionStyles } from "../MultiSelect/MultiSelect";
 
 export interface SelectProps {
     label: string;
@@ -30,18 +31,18 @@ export const Select: FC<SelectProps> = ({
     const inputRef = useRef<HTMLInputElement | null>(null);
     const comboboxButtonRef = useRef<HTMLButtonElement | null>(null); // Added ref for Combobox.Button
 
-    useEffect(() => {
-        if (onChange) onChange(selected);
-    }, [selected, onChange]);
-
     const handleChange = (opt: string) => {
         setSelected(opt);
+        if (onChange) onChange(selected);
     };
 
     useEffect(() => {
         const handleKeyDown = (event: KeyboardEvent) => {
-            if (event.key === "ArrowDown" && inputRef.current === document.activeElement) {
-                setQuery('');
+            if (
+                event.key === "ArrowDown" &&
+                inputRef.current === document.activeElement
+            ) {
+                setQuery("");
             }
         };
 
@@ -52,11 +53,12 @@ export const Select: FC<SelectProps> = ({
         };
     }, []);
 
-    const filteredOptions = query === ""
-        ? options
-        : options.filter((opt) => {
-              return opt.toLowerCase().includes(query.toLowerCase());
-          });
+    const filteredOptions =
+        query === ""
+            ? options
+            : options.filter((opt) => {
+                  return opt.toLowerCase().includes(query.toLowerCase());
+              });
 
     return (
         <Combobox
@@ -65,12 +67,13 @@ export const Select: FC<SelectProps> = ({
             onChange={handleChange}
             disabled={disabled}
             name={name}
-            onInputValueChange={({ inputValue }) => {
-                setQuery(inputValue || "");
-            }}
         >
             <div className="relative">
-                <Combobox.Label className={`block text-sm font-medium ${srLabelOnly ? " sr-only" : ""}`}>
+                <Combobox.Label
+                    className={`block text-sm font-medium ${
+                        srLabelOnly ? " sr-only" : ""
+                    }`}
+                >
                     {label}
                     {required && <span className="text-red-500">*</span>}
                 </Combobox.Label>
@@ -79,12 +82,18 @@ export const Select: FC<SelectProps> = ({
                         className="w-full border-none py-2 pl-3 pr-10 text-sm leading-5 text-gray-900 bg-gray-50 focus:ring-0"
                         displayValue={(option: string) => option}
                         onChange={(event) => setQuery(event.target.value)}
-                        onFocus={() => setQuery('')}
+                        onFocus={() => setQuery("")}
                         ref={inputRef}
                         onClick={() => comboboxButtonRef.current?.click()} // Added to handle click and focus event to open the combobox
                     />
-                    <Combobox.Button className="absolute inset-y-0 right-0 flex items-center pr-2" ref={comboboxButtonRef}>
-                        <ChevronUpDownIcon className="w-5 h-5 text-gray-400" aria-hidden="true" />
+                    <Combobox.Button
+                        className="absolute inset-y-0 right-0 flex items-center pr-2"
+                        ref={comboboxButtonRef}
+                    >
+                        <ChevronUpDownIcon
+                            className="w-5 h-5 text-gray-400"
+                            aria-hidden="true"
+                        />
                     </Combobox.Button>
                 </div>
                 <Transition
@@ -94,7 +103,7 @@ export const Select: FC<SelectProps> = ({
                     leaveTo="opacity-0"
                     afterLeave={() => setQuery("")}
                 >
-                    <Combobox.Options className="absolute mt-1 max-h-60 w-full overflow-auto rounded-md bg-white shadow-lg ring-1 ring-black ring-opacity-5 focus:outline-none z-10">
+                    <Combobox.Options className="absolute border border-charcoalBlack mt-1 max-h-60 z-50 w-full overflow-auto bg-gray-50 py-1 text-base">
                         {filteredOptions.length === 0 && query !== "" ? (
                             <div className="cursor-default select-none relative py-2 px-4 text-gray-700">
                                 Nothing found.
@@ -103,19 +112,32 @@ export const Select: FC<SelectProps> = ({
                             filteredOptions.map((option) => (
                                 <Combobox.Option
                                     key={option}
-                                    className={({ active }) =>
-                                        `cursor-default select-none relative py-2 pl-10 pr-4 ${active ? "bg-blue-500 text-white" : "text-gray-900"}`
-                                    }
+                                    className={getOptionStyles}
                                     value={option}
                                 >
                                     {({ selected, active }) => (
                                         <>
-                                            <span className={`block truncate ${selected ? "font-medium" : "font-normal"}`}>
+                                            <span
+                                                className={`block truncate ${
+                                                    selected
+                                                        ? "font-medium"
+                                                        : "font-normal"
+                                                }`}
+                                            >
                                                 {option}
                                             </span>
                                             {selected && (
-                                                <span className={`absolute inset-y-0 left-0 flex items-center pl-3 ${active ? "text-white" : "text-teal-600"}`}>
-                                                    <CheckIcon className="w-5 h-5" aria-hidden="true" />
+                                                <span
+                                                    className={`absolute inset-y-0 left-0 flex items-center pl-3 ${
+                                                        active
+                                                            ? "text-white"
+                                                            : "text-teal-600"
+                                                    }`}
+                                                >
+                                                    <CheckIcon
+                                                        className="w-5 h-5"
+                                                        aria-hidden="true"
+                                                    />
                                                 </span>
                                             )}
                                         </>

--- a/src/components/Select/Select.tsx
+++ b/src/components/Select/Select.tsx
@@ -1,7 +1,6 @@
-import { FC, Fragment, useState } from "react";
+import { FC, Fragment, useState, useRef, useEffect } from "react";
 import { Combobox, Transition } from "@headlessui/react";
 import { CheckIcon, ChevronUpDownIcon } from "@heroicons/react/20/solid";
-import { getOptionStyles } from "../MultiSelect/MultiSelect";
 
 export interface SelectProps {
     label: string;
@@ -28,51 +27,64 @@ export const Select: FC<SelectProps> = ({
 }) => {
     const [selected, setSelected] = useState<string>(initialValue);
     const [query, setQuery] = useState("");
+    const inputRef = useRef<HTMLInputElement | null>(null);
+    const comboboxButtonRef = useRef<HTMLButtonElement | null>(null); // Added ref for Combobox.Button
+
+    useEffect(() => {
+        if (onChange) onChange(selected);
+    }, [selected, onChange]);
 
     const handleChange = (opt: string) => {
         setSelected(opt);
-        if (onChange) onChange(opt);
     };
 
-    const filteredOptions =
-        query === ""
-            ? options
-            : options.filter((opt) => {
-                  return opt
-                      .toLowerCase()
-                      .trim()
-                      .includes(query.toLowerCase().trim());
-              });
+    useEffect(() => {
+        const handleKeyDown = (event: KeyboardEvent) => {
+            if (event.key === "ArrowDown" && inputRef.current === document.activeElement) {
+                setQuery('');
+            }
+        };
+
+        document.addEventListener("keydown", handleKeyDown);
+
+        return () => {
+            document.removeEventListener("keydown", handleKeyDown);
+        };
+    }, []);
+
+    const filteredOptions = query === ""
+        ? options
+        : options.filter((opt) => {
+              return opt.toLowerCase().includes(query.toLowerCase());
+          });
 
     return (
         <Combobox
-            name={name}
+            as="div"
             value={selected}
-            onChange={onChange ? handleChange : undefined}
+            onChange={handleChange}
             disabled={disabled}
+            name={name}
+            onInputValueChange={({ inputValue }) => {
+                setQuery(inputValue || "");
+            }}
         >
             <div className="relative">
-                <Combobox.Label
-                    className={`block font-medium leading-6 text-charcoalBlack text-md${
-                        srLabelOnly ? " sr-only" : ""
-                    }`}
-                >
+                <Combobox.Label className={`block text-sm font-medium ${srLabelOnly ? " sr-only" : ""}`}>
                     {label}
-                    {required ? (
-                        <span className="text-red-600 ml-1">*</span>
-                    ) : null}
+                    {required && <span className="text-red-500">*</span>}
                 </Combobox.Label>
                 <div className="relative w-full mt-2 cursor-default overflow-hidden bg-gray-50 text-left border border-charcoalBlack">
                     <Combobox.Input
                         className="w-full border-none py-2 pl-3 pr-10 text-sm leading-5 text-gray-900 bg-gray-50 focus:ring-0"
-                        displayValue={(opt: string) => opt}
+                        displayValue={(option: string) => option}
                         onChange={(event) => setQuery(event.target.value)}
+                        onFocus={() => setQuery('')}
+                        ref={inputRef}
+                        onClick={() => comboboxButtonRef.current?.click()} // Added to handle click and focus event to open the combobox
                     />
-                    <Combobox.Button className="absolute inset-y-0 right-0 flex items-center pr-2">
-                        <ChevronUpDownIcon
-                            className="h-5 w-5 text-gray-400"
-                            aria-hidden="true"
-                        />
+                    <Combobox.Button className="absolute inset-y-0 right-0 flex items-center pr-2" ref={comboboxButtonRef}>
+                        <ChevronUpDownIcon className="w-5 h-5 text-gray-400" aria-hidden="true" />
                     </Combobox.Button>
                 </div>
                 <Transition
@@ -82,41 +94,30 @@ export const Select: FC<SelectProps> = ({
                     leaveTo="opacity-0"
                     afterLeave={() => setQuery("")}
                 >
-                    <Combobox.Options className="absolute border border-charcoalBlack mt-1 max-h-60 z-50 w-full overflow-auto bg-gray-50 py-1 text-base">
-                        {allowCustomValue && query.length > 0 ? (
-                            <Combobox.Option
-                                className={getOptionStyles}
-                                value={query}
-                            >{`Self-described as "${query}"`}</Combobox.Option>
-                        ) : null}
+                    <Combobox.Options className="absolute mt-1 max-h-60 w-full overflow-auto rounded-md bg-white shadow-lg ring-1 ring-black ring-opacity-5 focus:outline-none z-10">
                         {filteredOptions.length === 0 && query !== "" ? (
-                            <div className="relative cursor-default select-none px-4 py-2 text-gray-700">
+                            <div className="cursor-default select-none relative py-2 px-4 text-gray-700">
                                 Nothing found.
                             </div>
                         ) : (
-                            filteredOptions.map((opt) => (
+                            filteredOptions.map((option) => (
                                 <Combobox.Option
-                                    key={opt}
-                                    className={getOptionStyles}
-                                    value={opt}
+                                    key={option}
+                                    className={({ active }) =>
+                                        `cursor-default select-none relative py-2 pl-10 pr-4 ${active ? "bg-blue-500 text-white" : "text-gray-900"}`
+                                    }
+                                    value={option}
                                 >
                                     {({ selected, active }) => (
                                         <>
-                                            <span>{opt}</span>
-                                            {selected ? (
-                                                <span
-                                                    className={`absolute inset-y-0 right-0 flex items-center pr-3 ${
-                                                        active
-                                                            ? "text-white"
-                                                            : "text-green-600"
-                                                    }`}
-                                                >
-                                                    <CheckIcon
-                                                        className="h-5 w-5"
-                                                        aria-hidden="true"
-                                                    />
+                                            <span className={`block truncate ${selected ? "font-medium" : "font-normal"}`}>
+                                                {option}
+                                            </span>
+                                            {selected && (
+                                                <span className={`absolute inset-y-0 left-0 flex items-center pl-3 ${active ? "text-white" : "text-teal-600"}`}>
+                                                    <CheckIcon className="w-5 h-5" aria-hidden="true" />
                                                 </span>
-                                            ) : null}
+                                            )}
                                         </>
                                     )}
                                 </Combobox.Option>


### PR DESCRIPTION
🐛 [Filtered dropdowns should bring up options on click #109](https://github.com/LaurierHawkHacks/Dashboard/issues/109)

🔍 **What's Included**
- Fixed `Select.tsx` to open dropdown options on click anywhere within the input.
    - https://github.com/tailwindlabs/headlessui/discussions/1236
- Introduced `useRef` for input and combobox button to manage focus and clicks.
- Implemented `useEffect` to handle keydown events for improved accessibility.

📁 Files Affected:
- `src/components/Select/Select.tsx`