### PR TITLE
Fix: prioritise Canada and the USA at the top of countryNames list

### DIFF
--- a/src/data/countryNames.ts
+++ b/src/data/countryNames.ts
@@ -1,4 +1,6 @@
 const countryNames = [
+    'Canada',
+    'United States',
     'Afghanistan',
     'Åland Islands',
     'Albania',
@@ -37,7 +39,6 @@ const countryNames = [
     'Burundi',
     'Cambodia',
     'Cameroon',
-    'Canada',
     'Cape Verde',
     'Cayman Islands',
     'Central African Republic',
@@ -228,7 +229,6 @@ const countryNames = [
     'Ukraine',
     'United Arab Emirates',
     'United Kingdom',
-    'United States',
     'United States Minor Outlying Islands',
     'Uruguay',
     'Uzbekistan',


### PR DESCRIPTION
Issue: #150 

🔍 What's Included
- Updated countryNames.ts to prioritize "Canada" and "USA" at the top of the country list

📁 Files Affected:
- src/data/countryNames.ts