### PR TITLE
fix/144/Race-Ethnicity-question-shouldn't-let-the-user-select-a-custom-option

### DIFF
--- a/src/components/forms/hackerApplication.ts
+++ b/src/components/forms/hackerApplication.ts
@@ -53,7 +53,7 @@ export const hackerAppFormInputs: FormInput[] = [
             label: "Which of the following best describes your racial or ethnic background?",
             initialValue: "",
             options: races,
-            allowCustomValue: true,
+            allowCustomValue: false,
             required: true,
         },
         name: "race",

--- a/src/data/index.ts
+++ b/src/data/index.ts
@@ -44,6 +44,7 @@ export const races = [
     "Vietnamese",
     "White",
     "Prefer not to answer",
+    "My racial or ethnic background isn't listed",
 ];
 
 export const diets = [


### PR DESCRIPTION
Added the following option to races array: "My racial or ethnic background isn't listed"

Removed ability to input custom value for race/ethnicity question
