### PR TITLE
normalize hint text colour for inputs

### DIFF
--- a/src/components/Select/Select.tsx
+++ b/src/components/Select/Select.tsx
@@ -178,7 +178,7 @@ export const Select: FC<SelectProps> = ({
                     </Combobox.Options>
                 </Transition>
                 {allowCustomValue ? (
-                    <span className="block mt-2">
+                    <span className="block mt-2 text-sageGray">
                         Not in the options? Type your answer in the input field.
                     </span>
                 ) : null}

--- a/src/components/TextInput/TextInput.styles.ts
+++ b/src/components/TextInput/TextInput.styles.ts
@@ -41,7 +41,7 @@ export const getTextInputLabelStyles = cva(
     }
 );
 
-const textInputDescriptionStyles = cva("mt-2 text-sm text-[#32848C]", {
+const textInputDescriptionStyles = cva("mt-2 text-sm text-sageGray", {
     variants: {
         invalid: {
             true: "text-red-500",


### PR DESCRIPTION
There were inconsistencies with the hint/description colour under inputs. This fixes that.