### PR TITLE
Feature/184-change-input-focus-color

### DIFF
--- a/src/components/TextInput/TextInput.styles.ts
+++ b/src/components/TextInput/TextInput.styles.ts
@@ -5,7 +5,7 @@ import { twMerge } from "tailwind-merge";
 const textInputStyles = cva(
     [
         "block w-full py-2 px-3 bg-gray-50 text-gray-900 placeholder:text-sageGray", // base
-        "focus:ring-2 focus:ring-inset focus:ring-[#0FA3B1]", // focus styles
+        "focus:ring-2 focus:ring-inset focus:ring-[#00848C]", // focus styles
     ],
     {
         variants: {

--- a/src/components/TextInput/TextInput.styles.ts
+++ b/src/components/TextInput/TextInput.styles.ts
@@ -5,7 +5,7 @@ import { twMerge } from "tailwind-merge";
 const textInputStyles = cva(
     [
         "block w-full py-2 px-3 bg-gray-50 text-gray-900 placeholder:text-sageGray", // base
-        "focus:ring-2 focus:ring-inset", // focus styles
+        "focus:ring-2 focus:ring-inset focus:ring-[#0FA3B1]", // focus styles
     ],
     {
         variants: {


### PR DESCRIPTION
🎨[Change the Active Color of Text Inputs from Blue to HawkHacks Green #184](https://github.com/LaurierHawkHacks/Dashboard/issues/184)

🔍 **What's Included**
- Updated the focus ring color in text inputs to HawkHacks green in `TextInput.styles.ts`.

📁 Files Affected:
- `src/components/TextInput/TextInput.styles.ts`