### PR TITLE
233-handle-auth-popup-blocked-error-properly

### DIFF
--- a/src/providers/auth.provider.tsx
+++ b/src/providers/auth.provider.tsx
@@ -106,14 +106,17 @@ function getNotificationByAuthErrCode(code: string): NotificationOptions {
         case "auth/email-already-in-use":
             return {
                 title: "Email In Use",
-                message:
-                    "If you forgot your password, click on 'forgot password' to recover it!",
+                message: "If you forgot your password, click on 'forgot password' to recover it!",
             };
         case "auth/invalid-login-credentials":
             return {
                 title: "Invalid Credentials",
-                message:
-                    "Please make sure you have the correct credentials and try again.",
+                message: "Please make sure you have the correct credentials and try again.",
+            };
+        case "auth/popup-blocked":
+            return {
+                title: "Login Blocked",
+                message: "Popup windows are blocked. Please allow them in your browser settings to continue.",
             };
         default:
             return {


### PR DESCRIPTION
🔧 [Handle auth/popup-blocked error properly #233](https://github.com/LaurierHawkHacks/Dashboard/issues/233)

🔍 **What's Included**
- Added handling for 'auth/popup-blocked' error in `auth.provider.tsx` to show a message prompting users to allow popups in their browser settings.

📁 Files Affected:
- `src/providers/auth.provider.tsx`