### PR TITLE
Feature/358/limit-rsvps-after-a-certain-cutoff-date-to-700

### DIFF
--- a/config/firestore.rules
+++ b/config/firestore.rules
@@ -25,6 +25,11 @@ service cloud.firestore {
       allow write: if isAuthenticated() && isAdmin();
     }
 
+    // RSVP Counter Collection Rules
+    match /rsvpCounter/{counterId} {
+        allow read, write: if isAuthenticated() && isAdmin();
+    }
+
     // Tickets Collection Rules
     match /tickets/{ticketId} {
         // Only grant read perms to owner/admin

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -401,11 +401,11 @@ export const verifyRSVP = functions.https.onCall(async (_, context) => {
         return {
             status: 200,
             verified: true,
+            message: "RSVP already verified.",
         };
     } else {
         const currentDate = new Date();
-        const limitDate = new Date("2024-05-08");
-
+        const limitDate = new Date("2024-05-08T23:59:00");
         if (currentDate > limitDate) {
             const counterDocRef = admin.firestore().collection("rsvpCounter").doc("counter");
             const counterDoc = await counterDocRef.get();

--- a/src/pages/miscellaneous/VerifyRSVP.page.tsx
+++ b/src/pages/miscellaneous/VerifyRSVP.page.tsx
@@ -10,23 +10,28 @@ export const VerifyRSVP = () => {
     const [isVerifying, setIsVerifying] = useState(false);
     const [agreedToParticipate, setAgreedToParticipate] = useState(false);
     const [willAttend, setWillAttend] = useState(false);
+    const [rsvpLimitReached, setRsvpLimitReached] = useState(false);
     const { showNotification } = useNotification();
     const { currentUser, reloadUser } = useAuth();
     const navigate = useNavigate();
 
     const verify = async () => {
         setIsVerifying(true);
-        const confirmed = await verifyRSVP();
-        if (!confirmed) {
-            setIsVerifying(false);
-            showNotification({
-                title: "Error Verifying RSVP",
-                message:
-                    "Please reach out to us in our tech support channel on Discord.",
-            });
-        } else {
+        const { status, verified, message } = await verifyRSVP();
+        if (status === 200 && verified) {
             await reloadUser();
             setIsVerifying(false);
+        } else {
+            setIsVerifying(false);
+            if (status === 400 && message === "RSVP limit reached.") {
+                setRsvpLimitReached(true);
+            } else {
+                showNotification({
+                    title: "Error Verifying RSVP",
+                    message:
+                        "Please reach out to us in our tech support channel on Discord.",
+                });
+            }
         }
     };
 
@@ -40,74 +45,88 @@ export const VerifyRSVP = () => {
                 <LoadingAnimation text="Loading . . ." />
             ) : (
                 <div className="pt-12 flex justify-center items-center flex-col gap-6">
-                    <p className="text-lg font-bold">
-                        Please verify your RSVP to get access to the rest of the
-                        dashboard!
-                    </p>
-                    <div className="flex flex-col items-start max-w-3xl">
-                        <div>
-                            <label className="inline-flex items-center gap-3 mt-3">
-                                <input
-                                    type="checkbox"
-                                    checked={agreedToParticipate}
-                                    onChange={(e) =>
-                                        setAgreedToParticipate(e.target.checked)
-                                    }
-                                    className="form-checkbox h-5 w-5 text-gray-600"
-                                />
-                                <span className="ml-2 text-gray-700 cursor-pointer">
-                                    I have read the content below and agree to
-                                    participate in the event using my free will
-                                    and good judgment.
-                                </span>
-                            </label>
-
-                            <div className="border border-blueGreen p-2 my-8 flex flex-col gap-2 text-gray-500 max-w-3xl max-h-72 overflow-y-scroll">
-                                {rsvpText.map((content, index) => {
-                                    return <p key={index}>{content}</p>;
-                                })}
-                            </div>
+                    {rsvpLimitReached ? (
+                        <div className="text-center">
+                            <p className="text-lg font-bold text-red-500">
+                                RSVP Limit Reached
+                            </p>
+                            <p className="text-gray-700 mt-2">
+                                We're sorry, but the RSVP limit has been reached.
+                                If you have any questions or concerns, please reach out to us in our tech support channel on Discord.
+                            </p>
                         </div>
-                        <label className="inline-flex items-center gap-3 mt-3">
-                            <input
-                                type="checkbox"
-                                checked={willAttend}
-                                onChange={(e) =>
-                                    setWillAttend(e.target.checked)
+                    ) : (
+                        <>
+                            <p className="text-lg font-bold">
+                                Please verify your RSVP to get access to the rest of the
+                                dashboard!
+                            </p>
+                            <div className="flex flex-col items-start max-w-3xl">
+                                <div>
+                                    <label className="inline-flex items-center gap-3 mt-3">
+                                        <input
+                                            type="checkbox"
+                                            checked={agreedToParticipate}
+                                            onChange={(e) =>
+                                                setAgreedToParticipate(e.target.checked)
+                                            }
+                                            className="form-checkbox h-5 w-5 text-gray-600"
+                                        />
+                                        <span className="ml-2 text-gray-700 cursor-pointer">
+                                            I have read the content below and agree to
+                                            participate in the event using my free will
+                                            and good judgment.
+                                        </span>
+                                    </label>
+
+                                    <div className="border border-blueGreen p-2 my-8 flex flex-col gap-2 text-gray-500 max-w-3xl max-h-72 overflow-y-scroll">
+                                        {rsvpText.map((content, index) => {
+                                            return <p key={index}>{content}</p>;
+                                        })}
+                                    </div>
+                                </div>
+                                <label className="inline-flex items-center gap-3 mt-3">
+                                    <input
+                                        type="checkbox"
+                                        checked={willAttend}
+                                        onChange={(e) =>
+                                            setWillAttend(e.target.checked)
+                                        }
+                                        className="form-checkbox h-5 w-5 text-gray-600"
+                                    />
+                                    <span className="ml-2 text-gray-700">
+                                        I confirm that I will be attending HawkHacks
+                                        from May 17th to May 19th. I will try to be on
+                                        the premises for the vast majority for the
+                                        duration of the event.
+                                    </span>
+                                </label>
+                            </div>
+
+                            <Button
+                                onClick={verify}
+                                disabled={
+                                    isVerifying || !agreedToParticipate || !willAttend
                                 }
-                                className="form-checkbox h-5 w-5 text-gray-600"
-                            />
-                            <span className="ml-2 text-gray-700">
-                                I confirm that I will be attending HawkHacks
-                                from May 17th to May 19th. I will try to be on
-                                the premises for the vast majority for the
-                                duration of the event.
-                            </span>
-                        </label>
-                    </div>
+                                className="mt-4 font-bold px-4 py-2 rounded bg-blue-500 text-white disabled:bg-gray-300"
+                            >
+                                Verify
+                            </Button>
 
-                    <Button
-                        onClick={verify}
-                        disabled={
-                            isVerifying || !agreedToParticipate || !willAttend
-                        }
-                        className="mt-4 font-bold px-4 py-2 rounded bg-blue-500 text-white disabled:bg-gray-300"
-                    >
-                        Verify
-                    </Button>
-
-                    <p className="text-gray-800 mt-2">
-                        Having trouble? Get help in our{" "}
-                        <a
-                            href="https://discord.com/invite/GxwvFEn9TB"
-                            target="_blank"
-                            rel="noopener noreferrer"
-                            className="text-sky-600 font-bold underline"
-                        >
-                            Discord
-                        </a>{" "}
-                        support channel.
-                    </p>
+                            <p className="text-gray-800 mt-2">
+                                Having trouble? Get help in our{" "}
+                                <a
+                                    href="https://discord.com/invite/GxwvFEn9TB"
+                                    target="_blank"
+                                    rel="noopener noreferrer"
+                                    className="text-sky-600 font-bold underline"
+                                >
+                                    Discord
+                                </a>{" "}
+                                support channel.
+                            </p>
+                        </>
+                    )}
                 </div>
             )}
         </>

--- a/src/services/utils/index.ts
+++ b/src/services/utils/index.ts
@@ -232,8 +232,8 @@ export async function verifyRSVP() {
     const verifyFn = httpsCallable(functions, "verifyRSVP");
     try {
         const res = await verifyFn();
-        const data = res.data as { verified: boolean };
-        return data.verified;
+        const data = res.data as { status: number; verified: boolean; message?: string };
+        return data;
     } catch (e) {
         logEvent("error", {
             event: "verify_rsvp",
@@ -241,10 +241,9 @@ export async function verifyRSVP() {
             name: (e as Error).name,
             stack: (e as Error).stack,
         });
-        return false;
+        return { status: 500, verified: false, message: "Internal server error" };
     }
 }
-
 export async function getSocials() {
     const fn = httpsCallable<unknown, CloudFunctionResponse<Socials>>(
         functions,


### PR DESCRIPTION
📆 [Limit RSVPs After a Certain Cutoff Date to 700 #358](https://github.com/LaurierHawkHacks/Dashboard/issues/358)

🔍 **What's Included**
- Added functionality to limit RSVPs to 700 after a specific date in `index.ts`.
- Updated RSVP verification logic and user interface feedback on reaching limit in `VerifyRSVP.page.tsx`.
- Adjusted error handling and RSVP status feedback in `utils/index.ts`.
- Added Firestore rule to restrict rsvpCounter read/writes to admins.

📁 Files Affected:
- `functions/src/index.ts`
- `src/pages/miscellaneous/VerifyRSVP.page.tsx`
- `src/services/utils/index.ts`
- `config/firestore.rules`