### PR TITLE
Fix/365/remove nibiru from the sponsor section

### DIFF
--- a/src/data/sponsorLinks.ts
+++ b/src/data/sponsorLinks.ts
@@ -1,14 +1,13 @@
 const sponsorLinks = {
     // platinum
-    avalanche: "https://www.avax.network/",
-    near: "https://near.org/",
+    avalanche: "https://www.avax.network/?utm_medium=affiliate&utm_term=&utm_content&utm_campaign=hawkhacks24",
+    near: "https://near.org/?utm_medium=affiliate&utm_term=&utm_content&utm_campaign=hawkhacks24",
 
     // gold
-    fantuan: "https://fantuan.ca/delivery/en/",
-    sp: "https://smokespoutinerie.com/",
-    domino: "https://www.dominos.ca/en/",
-    nibiru: "https://nibiru.fi/",
-    distributive: "https://distributive.network/",
+    fantuan: "https://fantuan.ca/delivery/en/?utm_medium=affiliate&utm_term=&utm_content&utm_campaign=hawkhacks24",
+    sp: "https://smokespoutinerie.com/?utm_medium=affiliate&utm_term=&utm_content&utm_campaign=hawkhacks24",
+    domino: "https://www.dominos.ca/en/?utm_medium=affiliate&utm_term=&utm_content&utm_campaign=hawkhacks24",
+    distributive: "https://distributive.network/?utm_medium=affiliate&utm_term=&utm_content&utm_campaign=hawkhacks24",
 };
 
 export { sponsorLinks };

--- a/src/data/sponsors.ts
+++ b/src/data/sponsors.ts
@@ -43,11 +43,6 @@ const sponsors: Sponsor[] = [
         image: Dominos,
     },
     {
-        name: "Nibiru",
-        link: sponsorLinks.nibiru,
-        image: Nibiru,
-    },
-    {
         name: "Distributive",
         link: sponsorLinks.distributive,
         image: Distributive,

--- a/src/data/sponsors.ts
+++ b/src/data/sponsors.ts
@@ -5,7 +5,6 @@ import {
     Fantuan,
     SmokesPoutinerie,
     Dominos,
-    Nibiru,
     Distributive,
 } from "@assets";
 


### PR DESCRIPTION
Issue: #365 
Branch: [fix/365/remove-nibiru-from-the-sponsor-section](https://github.com/LaurierHawkHacks/Dashboard/compare/dev...fix/365/remove-nibiru-from-the-sponsor-section?expand=1)

Why?
- Nibiru didn't sponsor HawkHacks anymore.
- Update sponsor's campaign link